### PR TITLE
Fix #12 closeout_task is not defined when tasks is empty

### DIFF
--- a/aiopylgtv/webos_client.py
+++ b/aiopylgtv/webos_client.py
@@ -375,11 +375,11 @@ class WebOsClient:
             if tasks:
                 closeout_task = asyncio.create_task(asyncio.wait(tasks))
 
-            while not closeout_task.done():
-                try:
-                    await asyncio.shield(closeout_task)
-                except asyncio.CancelledError:
-                    pass
+                while not closeout_task.done():
+                    try:
+                        await asyncio.shield(closeout_task)
+                    except asyncio.CancelledError:
+                        pass
 
     # manage state
     @property


### PR DESCRIPTION
Fix #12 closeout_task is not defined when tasks is empty