### PR TITLE
Fix the loss of the channel callback

### DIFF
--- a/aiopylgtv/webos_client.py
+++ b/aiopylgtv/webos_client.py
@@ -4,6 +4,7 @@ import copy
 import json
 import logging
 import os
+import time
 
 import numpy as np
 import websockets
@@ -523,8 +524,9 @@ class WebOsClient:
             except PyLGTVCmdException:
                 pass
 
-        if appId == "com.webos.app.livetv" and self._current_channel is None:
+        if appId == "com.webos.app.livetv":
             try:
+                time.sleep(1)
                 await self.subscribe_current_channel(self.set_current_channel_state)
             except PyLGTVCmdException:
                 pass


### PR DESCRIPTION
I stumbled upon an issue where the current channel subscription is lost and self._current_channel is never updated again. Steps to reproduce:
1. start on the Live TV app
2. switch input to HDMI
3. go back to Live TV

In that case self._current_channel would stay on the channel that has been set during step 1. Seems like the ep.GET_CURRENT_CHANNEL subscription is lost when the TV switches from Live TV to an HDMI input.
With this pull request  the current channel subscription is restored when the TV is switched back to Live TV. 
The time.sleep seems to be necessary because an immediate setting of the current channel  subscription as soon as set_current_app_state is called does not work (I suspect an race condition somewhere?). Let me know in case there is a better way!