### PR TITLE
Fix volume read status

### DIFF
--- a/aiopylgtv/webos_client.py
+++ b/aiopylgtv/webos_client.py
@@ -878,13 +878,16 @@ class WebOsClient:
     async def get_volume(self):
         """Get the current volume."""
         res = await self.request(ep.GET_VOLUME)
-        return res.get("volume")
+        status = res.get("volumeStatus")
+        return status.get("volume") if status else None
 
     async def subscribe_volume(self, callback):
         """Subscribe to changes in the current volume."""
 
         async def volume(payload):
-            await callback(payload.get("volume"))
+            status = payload.get("volumeStatus")
+            volumeLevel = status.get("volume") if status else None
+            await callback(volumeLevel)
 
         return await self.subscribe(volume, ep.GET_VOLUME)
 


### PR DESCRIPTION
Previously, the volume reported by Home Assistant for my LG TV was always "NaN".
This is due to the fact that the payload returned by the library contains "volume",
but wrapped in an outer structure of "volumeStatus". This PR fixes this and now
Home Assistant correctly reports the current value of volume.

Tested by running modified version of code in Home Assistant.

More details can be found here: https://www.webosose.org/docs/reference/ls2-api/com-webos-service-audio/#master-getvolume