### PR TITLE
Add support for dictionary and list types in cmd line params

### DIFF
--- a/aiopylgtv/utils.py
+++ b/aiopylgtv/utils.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import json
 
 from aiopylgtv import WebOsClient
 
@@ -18,6 +19,10 @@ def convert_arg(arg):
         pass
     try:
         return float(arg)
+    except ValueError:
+        pass
+    try:
+        return json.loads(arg)
     except ValueError:
         pass
     if arg.lower() == "true":


### PR DESCRIPTION
There's no need to write scripts just because of these anymore, command line examples (note the escaping of quotes):
```sh
aiopylgtvcommand 192.168.1.18 set_current_picture_settings "{\"backlight\": 0, \"contrast\": 65}"
aiopylgtvcommand 192.168.1.18 launch_app_with_params com.webos.app.softwareupdate "{\"mode\": \"user\", \"flagUpdate\": true}"
aiopylgtvcommand 192.168.1.18 get_picture_settings "[\"contrast\", \"backlight\"]"
# Launch In-Start Service Menu (code: 0413) (using JSON)
aiopylgtvcommand 192.168.1.18 launch_app_with_params com.webos.app.factorywin "{\"id\": \"executeFactory\", \"irKey\": \"inStart\"}"
# Launch Ez-Adjust Service Menu (code: 0413) (using JSON)
aiopylgtvcommand 192.168.1.18 launch_app_with_params com.webos.app.factorywin "{\"id\": \"executeFactory\", \"irKey\": \"ezAdjust\"}"
```

This can work in bash on Linux (but not in cmd on Windows):
```sh
aiopylgtvcommand 192.168.1.18 set_current_picture_settings '{"backlight": 0, "contrast": 65}'
aiopylgtvcommand 192.168.1.18 launch_app_with_params com.webos.app.softwareupdate '{"mode": "user", "flagUpdate": true}'
aiopylgtvcommand 192.168.1.18 get_picture_settings '["contrast", "backlight"]'
aiopylgtvcommand 192.168.1.18 launch_app_with_params com.webos.app.factorywin '{"id": "executeFactory", "irKey": "inStart"}'
aiopylgtvcommand 192.168.1.18 launch_app_with_params com.webos.app.factorywin '{"id": "executeFactory", "irKey": "ezAdjust"}'
```

Relates to: https://github.com/bendavid/aiopylgtv/issues/30#issuecomment-870477410