### PR TITLE
Add support for setting PC mode for an HDMI input

### DIFF
--- a/aiopylgtv/webos_client.py
+++ b/aiopylgtv/webos_client.py
@@ -1435,6 +1435,23 @@ class WebOsClient:
 
         return await self.luna_request(uri, params)
 
+    async def set_pc_mode(self, pc_mode=True, hdmi_input="hdmi2"):
+        """Set PC mode for an HDMI input"""
+        inputs = ["hdmi1", "hdmi2", "hdmi3", "hdmi4"]
+
+        if hdmi_input not in inputs:
+            return
+
+        # Compose hdmiPcMode = {"hdmi1" : False, "hdmi2": True, "hdmi3" : False, "hdmi4" : False}
+        hdmiPcMode = {}
+        for i in inputs:
+            hdmiPcMode[i] = True if (pc_mode == True and i == hdmi_input) else False
+        
+        uri = "com.webos.settingsservice/setSystemSettings"
+        params = {"category": "other", "settings": {"hdmiPcMode": hdmiPcMode }}
+
+        return await self.luna_request(uri, params)
+
     def validateCalibrationData(self, data, shape, dtype):
         if not isinstance(data, np.ndarray):
             raise TypeError(f"data must be of type ndarray but is instead {type(data)}")

--- a/aiopylgtv/webos_client.py
+++ b/aiopylgtv/webos_client.py
@@ -1435,17 +1435,32 @@ class WebOsClient:
 
         return await self.luna_request(uri, params)
 
-    async def set_pc_mode(self, pc_mode=True, hdmi_input="hdmi2"):
-        """Set PC mode for an HDMI input."""
+    async def set_other_settings(self, settings):
+        """Set other settings.
 
-        inputs = ["hdmi1", "hdmi2", "hdmi3", "hdmi4"]
+        A possible list of settings and example values are below (not all settings are applicable
+        for all modes and/or tv models):
 
-        if hdmi_input not in inputs:
-            return
+        "gameOptimizationHDMI1": False,
+        "gameOptimizationHDMI2": False,
+        "gameOptimizationHDMI3": False,
+        "gameOptimizationHDMI4": False,
+        "hdmiPcMode": {
+            "hdmi1": False,
+            "hdmi2": False,
+            "hdmi3": False,
+            "hdmi4": False
+        },
+        "uhdDeepColorHDMI1": False,
+        "uhdDeepColorHDMI2": False,
+        "uhdDeepColorHDMI3": False,
+        "uhdDeepColorHDMI4": False
+
+        """
 
         uri = "com.webos.settingsservice/setSystemSettings"
 
-        params = {"category": "other", "settings": {"hdmiPcMode": {hdmi_input: pc_mode} }}
+        params = {"category": "other", "settings": settings}
 
         return await self.luna_request(uri, params)
 

--- a/aiopylgtv/webos_client.py
+++ b/aiopylgtv/webos_client.py
@@ -1436,19 +1436,16 @@ class WebOsClient:
         return await self.luna_request(uri, params)
 
     async def set_pc_mode(self, pc_mode=True, hdmi_input="hdmi2"):
-        """Set PC mode for an HDMI input"""
+        """Set PC mode for an HDMI input."""
+
         inputs = ["hdmi1", "hdmi2", "hdmi3", "hdmi4"]
 
         if hdmi_input not in inputs:
             return
 
-        # Compose hdmiPcMode = {"hdmi1" : False, "hdmi2": True, "hdmi3" : False, "hdmi4" : False}
-        hdmiPcMode = {}
-        for i in inputs:
-            hdmiPcMode[i] = True if (pc_mode == True and i == hdmi_input) else False
-        
         uri = "com.webos.settingsservice/setSystemSettings"
-        params = {"category": "other", "settings": {"hdmiPcMode": hdmiPcMode }}
+
+        params = {"category": "other", "settings": {"hdmiPcMode": {hdmi_input: pc_mode} }}
 
         return await self.luna_request(uri, params)
 


### PR DESCRIPTION
Using [this PR](https://github.com/bendavid/aiopylgtv/pull/34) as an example:
```sh
aiopylgtvcommand 192.168.1.18 set_other_settings "{\"hdmiPcMode\": {\"hdmi2\": false}}"
aiopylgtvcommand 192.168.1.18 set_other_settings "{\"hdmiPcMode\": {\"hdmi2\": true}}"
aiopylgtvcommand 192.168.1.18 set_other_settings "{\"hdmiPcMode\": {\"hdmi2\": false, \"hdmi3\": true}}"
```

Note: it changes PC vs non-PC modes fine, but the Input manager (com.webos.app.inputmgr) app and the Input button on the remote don't reflect the change.

Relates to: https://github.com/bendavid/aiopylgtv/issues/30#issuecomment-870494677