### PR TITLE
Add set_configs function

### DIFF
--- a/aiopylgtv/webos_client.py
+++ b/aiopylgtv/webos_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import copy
 import functools
 import json
 import logging

--- a/aiopylgtv/webos_client.py
+++ b/aiopylgtv/webos_client.py
@@ -1,6 +1,5 @@
 import asyncio
 import base64
-import copy
 import functools
 import json
 import logging
@@ -1432,6 +1431,23 @@ class WebOsClient:
             "category": f"picture${tv_input}.{pic_mode}.{stereoscopic}.x",
             "settings": settings,
         }
+
+        return await self.luna_request(uri, params)
+
+    async def set_configs(self, settings):
+        """Set config settings.
+
+        Example:
+
+        "com.palm.app.settings.foobar": False,
+        "tv.model.motionProMode": "OLED Motion",
+        "tv.model.motionProMode": "OLED Motion Pro"
+
+        """
+
+        uri = "com.webos.service.config/setConfigs"
+
+        params = {"configs": settings}
 
         return await self.luna_request(uri, params)
 


### PR DESCRIPTION
This can be used to enable "OLED Motion Pro" on C9, e.g. using [this PR](https://github.com/bendavid/aiopylgtv/pull/34):
```sh
aiopylgtvcommand 192.168.1.18 set_configs "{\"tv.model.motionProMode\": \"OLED Motion Pro\"}"
```

[Source](https://github.com/Maassoft/ColorControl/blob/7779533c1e48da4337b12a78da1340a564c80183/ColorControl/lgtv/LgTvApi.cs#L516).